### PR TITLE
ensure options object exist when not provided by the consuming application

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,9 @@ var originalFetch = window.fetch;
 window.fetch = function (request: RequestInfo, options?: RequestInit): Promise<Response> {
 
     return new Promise((resolve, reject) => {
+        // ensure an options object exists
+        options = options ? options : {};
+
         // Before filters
         filterChain.before(filters, request, options);
 

--- a/tests/basic/test.modifyRequest.html
+++ b/tests/basic/test.modifyRequest.html
@@ -9,7 +9,12 @@
         window.onload = function () {
             parent.run('Modifying response', function () {
 
-                var filterOrder = [];
+                // the first "before" gets executed after the second one. therefore we place the assertion before the actual change
+                addFetchFilter({
+                    before: function(settings, options) {
+                      assertEquals("test", options.headers["X-TEST"]);
+                    }
+                });
 
                 addFetchFilter({
                     before: function(settings, options) {
@@ -21,13 +26,6 @@
                                 "X-TEST": "test"
                             }
                         }
-                    }
-                });
-
-                addFetchFilter({
-                    before: function(settings, options) {
-                        assertEquals("test", options.headers["X-TEST"]);
-                        next();
                     }
                 });
 

--- a/tests/basic/test.modifyRequest.html
+++ b/tests/basic/test.modifyRequest.html
@@ -1,0 +1,44 @@
+<html>
+
+<head>
+    <script src='/tests/assert.js'></script>
+    <script src='/node_modules/promise-polyfill/promise.min.js'></script>
+    <script src='/node_modules/whatwg-fetch/fetch.js'></script>
+    <script src='/dist/fetch-filter.min.js'></script>
+    <script language='javascript'>
+        window.onload = function () {
+            parent.run('Modifying response', function () {
+
+                var filterOrder = [];
+
+                addFetchFilter({
+                    before: function(settings, options) {
+                        if(options.headers) {
+                            options.headers["X-TEST"] = "test";
+                        }
+                        else {
+                            options.headers = {
+                                "X-TEST": "test"
+                            }
+                        }
+                    }
+                });
+
+                addFetchFilter({
+                    before: function(settings, options) {
+                        assertEquals("test", options.headers["X-TEST"]);
+                        next();
+                    }
+                });
+
+                expectAsserts(1);
+                return fetch("grumpy-cat.jpg");
+            });
+        }
+    </script>
+</head>
+
+<body>
+</body>
+
+</html>

--- a/tests/basic/test.modifyRequestOptions.html
+++ b/tests/basic/test.modifyRequestOptions.html
@@ -7,7 +7,7 @@
     <script src='/dist/fetch-filter.min.js'></script>
     <script language='javascript'>
         window.onload = function () {
-            parent.run('Modifying response', function () {
+            parent.run('Modifying request options', function () {
 
                 // the first "before" gets executed after the second one. therefore we place the assertion before the actual change
                 addFetchFilter({


### PR DESCRIPTION
currently if a fetch request is made without an `options` parameter (`fetch(url)` or `fetch(RequestObject)`), there is no way to add more options in the `before` filters. we can ensure an options object is passed down to the filter function, allowing the users of fetch-filters to manipulate it as needed